### PR TITLE
feat: add clarity to UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -12,7 +11,6 @@
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="roadElement.js"></script>
   <script src="car.js"></script>
-  <script src="kdTree.js"></script>
   <title>Car Simulator</title>
   <style>
   </style>
@@ -20,34 +18,25 @@
 </head>
 <body>
     <div id="header">
-      <div id="menuIcon" onclick="displayMenu();">
-        <div class="bar"></div>
-        <div class="bar"></div>
-        <div class="bar"></div>
+      <div id = "menuIcon" class = "bar"></div>
+      <!-- Put additional pop-up messages here; class = note (regular msgs); Class = err (error msgs)-->
+      <p id = "pause" class = "note msg hide">Simulation is now paused.</p>
+      <p id = "reset" class = "note msg hide">Simulation reseted.</p>
+      <p id = "err0" class = "err msg hide">Error(0): You must create at least one complete road before changing modes.</p>
+      <div class = "sliderWrapper">
+        <label class = "switch" onclick = "keyReleased(true)">
+          <input id = "toggle1" type = "checkbox" disabled>
+          <span class = "slider"></span>
+        </label>
       </div>
+      <button id = "resetBtn" class = "resetBtn" onclick = "resetGrid()">Reset Simulation</button>
     </div>
-    <div id="continaer">
-      <div id="Instructions" class="">
-        <a href="javascript:void(0)" class="closebtn text-decoration-none" onclick="closeMenu();">&times;</a>
-        <p class="h1 text-primary">Instructions</p>
-        <ul class="text-info">
-          <li>To toggle between road construction and car instatiation click the spacebar</li>
-          <li>When in road construction mode</li>
-              <ul class="text-secondary">
-                <li>Left click to create a single road tile</li>
-                <li>Drag the mouse while pressing down the right click to continuously build road tiles</li>
-                <li>Right click to remove an end road tile</li>
-                <li>Right click a car to remove it</li>
-              </ul>
-          <li>When in car instantiation mode</li>
-              <ul class="text-secondary">
-                <li>Left click to create a single car sprite</li>
-                <li>Right click a car to remove it</li>
-              </ul>
-        </ul>
+    <div id="container">
+      <div id="menu" class="">
+        <!-- Add additional options listed inside the menu as needed -->
+        <button id = "Instructions" class = "option" onclick = "showText('Instructions')">Instructions</button>
+        <button id = "About" class = "option" onclick = "showText('About')">About</button>
       </div>
-
-
      <div id="CanvasParent" class="p-0 mx-0"></div>
     </div>
   <script src="index.js"></script>

--- a/index.js
+++ b/index.js
@@ -1,14 +1,83 @@
-var instructions = document.getElementById("Instructions");
+var menu = document.getElementById("menu");
 var canvas = document.getElementById("CanvasParent");
 var header = document.getElementById("header");
-function displayMenu(){
-    instructions.style.width="700px";
-    instructions.style.padding="10px";
-    canvas.addEventListener('click', closeMenu);
+
+let opList = [  // list of current options
+    `<button id = 'Instructions' class = 'option' onclick = 'showText("Instructions")'>Instructions</button>
+    <button id = 'About' class = 'option' onclick = 'showText("About")'>About</button>`
+].join("<br/>");
+
+let op1 = [     // Instructions section
+    `<p class="h1 text-primary margin">Instructions</p>
+    <ul class="text-info margin">
+        <li>Press either the <b>spacebar</b> or the <b>toggle</b> to switch between <b>Road Editting</b> and<br><b>Begin Simulation</b> modes.</li>
+        <li>Click <b>Reset Simulation</b> to clear the entire board. </li>
+        <li>When in <b>Road Editting</b> mode:</li>
+            <ul class="text-secondary">
+                <li><b>Left-click</b> to create a new road tile.</li>
+                <li>To continue building that road, <b>left-click</b> and <b>hold</b> the existing road tile and <b>drag</b><br> the mouse.</li>
+                <li>To remove connectivity from one tile to another, <b>left-click</b> and <b>hold</b> the initial tile<br> and <b>drag</b> to the tile you want to disconnect from.</li>
+                <li><b>Right-click</b> to remove a road tile with no connectivity.</li>
+                <li><b>Right-click</b> a car to remove it.</li>
+            </ul>
+        <li>When in <b>Begin Simulation</b> mode:</li>
+            <ul class="text-secondary">
+                <li><b>Left-click</b> a road tile with connectivity to create a single car entity.</li>
+                <li>(Future) <b>Right-click</b> to toggle traffic lights.</li>
+            </ul>
+    </ul>`
+].join("<br/>");
+
+let op2 = [     // About section (empty atm)
+    `<p class="h1 text-primary margin">About</p>
+    `
+];
+
+// opens and closes menu
+const btn = document.getElementById("menuIcon");
+btn.addEventListener("click", () => {
+    menuOpen = btn.classList.toggle("closebtn");
+    console.log(menuOpen);
+    if (menuOpen) {
+        menu.style.width="700px";
+    } else {
+        setTimeout(function() { menu.style.width="0px"; }, "100")
+    }
+});
+
+// Shows text in menu depending on option selected
+function showText(name) {
+    switch (name) {
+        case "Instructions":
+            menu.innerHTML = opList + op1;
+            return;
+        case "About":
+            menu.innerHTML = opList + op2;
+            return;
+    }
 }
-function closeMenu(){
-    instructions.style.width="0px";
-    //remove padding slightly before transition is complete
-    setTimeout(function(){instructions.style.padding="0";}, "500")
-    canvas.removeEventListener('click', closeMenu);
+
+// toggle between "Road Editting" and "Begin Simulation"
+function toggleMode(isValid, isReset = false) {
+    let initial = document.getElementById("toggle1");
+    if (isValid) { initial.outerHTML = "<input id = 'toggle1' type = 'checkbox' checked disabled>"; }
+    else { 
+        initial.outerHTML = "<input id = 'toggle1' type = 'checkbox' disabled>";
+        if (!isReset) { showMsg("pause"); }
+    }
+}
+
+// Given a message Id, fade-in and out the error message
+function showMsg(msgId) {
+    let message = document.getElementById(msgId);
+    message.classList.remove("hide");
+    setTimeout(function() {
+        message.classList.add("fade-in");
+        setTimeout(function() {
+            message.classList.remove("fade-in");
+            setTimeout(function() {
+                message.classList.add("hide");
+            }, 1000);
+        }, 3000);
+    });
 }

--- a/roadElement.js
+++ b/roadElement.js
@@ -27,10 +27,6 @@ class coordinate {
   }
 }
 
-// We could implement the car class to inherit its tile's coordinate class.
-// This way, the cars can operate on top of the roads without breaking road's properties
-// class car {}
-
 // compare x and y values of both tiles
 function areEqual(first, second) {
   if ((first.x === second.x) && (first.y === second.y)) { return true;  }

--- a/style.css
+++ b/style.css
@@ -23,26 +23,41 @@ canvas {
 cursor: pointer;
 }
 /* the menu bars within the menu Icon*/
-.bar{
-
-  width: 35px;
-  height: 3px;
-  background-color: black;
-  margin: 6px 0;
+.bar {
+  display: block;
+  width: 30%;
+  padding: 8px;
+  border: none;
+  outline: none;
+  cursor: pointer;
+  background: #E6E6FA;
+  color: #333333;
+  text-align: middle;
+  transition: 0.5s;
 }
-/* X button to close instructions menu*/
- .closebtn {
-  top: 0;
-  right: 25px;
-  font-size: 36px;
-  color: black;
-} 
+
+.bar::after {
+  content: '\2630';
+  font-weight: bold;
+  display: inline-block;
+  transform: scale(2);
+}
+
+.closebtn::after {
+  content: '\2715';
+  font-weight: bold;
+  display: inline-block;
+  transform: scale(2);
+}
+
 #CanvasParent{
   width:100%;
   z-index:1;
   height: calc(100vh - var(--headerHeight));
 }
-#Instructions{
+
+/* the contents of the menu */
+#menu{
   position: absolute;
   white-space: nowrap;
   box-sizing: border-box;
@@ -52,4 +67,132 @@ cursor: pointer;
   width:0px;
   background-color:aliceblue;
   overflow-x: hidden;
+}
+
+.margin {
+  margin-left: 1.5%;
+}
+
+.option {
+  border-color:#86e1f3;
+  background: #57d8f1;
+  position: static;
+  left: 50%;
+  margin-top: 2%;
+  margin-left: 1.8%;
+  display: inline-block;
+  width: 100px;
+  height: 25px;
+  text-align: center;
+}
+
+.option:hover {
+  border-color: #4cdaf7;
+  background: #24d4f7;
+}
+
+.resetBtn {
+  border-color: #f38ba2;
+  background: #f17e97;
+  position: absolute;
+  right: 0.2%;
+  top: 0.2%;
+  width: 150px;
+  padding: 8px;
+  cursor: pointer;
+  color: #333333;
+  text-align: middle;
+}
+
+.resetBtn:hover {
+  border-color: #f57994;
+  background: #f3587a;
+}
+
+/* the toggle indicator for the two modes */
+.switch {
+  position: relative;
+  display: flex;
+  margin: 0 auto;
+  bottom: 42px;
+  width: 80px;
+  height: 34px;
+}
+
+.switch input {
+  opacity: 0; width: 0; height: 0;
+}
+
+.slider {
+  background: #ccc;
+  position: absolute;
+  cursor: pointer;
+  /*top: 0.2%;*/
+  top: 0; left: 0; right: 0; bottom: 0;
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
+}
+
+.slider:before {
+  background-color: white;
+  position: absolute;
+  content: "";
+  height: 28px;
+  width: 36px;
+  left: 4px;
+  bottom: 3px;
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
+}
+
+input:checked + .slider {
+  background-color: #1fd637;
+}
+
+input:checked + .slider:before {
+  -webkit-transform: translateX(36px);
+  -ms-transform: translateX(36px);
+  transform: translateX(36px);
+}
+
+label::before {
+  content: "Road Editting";
+  margin-left: -70px;
+  line-height: 16px;
+}
+
+label::after {
+  content: "Begin Simulation";
+  margin-left: 110px;
+  line-height: 16px;
+}
+
+div.sliderWrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: row;
+}
+
+/* Enables messages to pop up and fade away; .err (error); .note (normal msg) */
+.err { color: #d84187; }
+.note { color: #329b2e; }
+
+.msg {
+  left: 65px;
+  top: 15px;
+  opacity: 0;
+  transition: 1s;
+  float: left;
+  position: absolute;
+}
+
+.msg.fade-in {
+  opacity: 1;
+  transition: 1s;
+}
+
+.msg.hide {
+  display: none;
+  user-select: none;
 }


### PR DESCRIPTION
This PR adds the following to the UI:
   - Buttons in the menu can change the text to be shown inside of it
   - Menu can now be opened and closed with a single button
   - A toggle indicator indicating which mode is currently activated; it can also be used to switch modes in addition to the spacebar
   - A reset button to remove all road tiles and car entities
   - The top leftish section of the header (where the menu button and reset buttons are) has been reserved for error messages and notifications in response to certain actions by the user and can fade-in and out.
      - If user attempts to activate **Begin Simulation** without a complete road, an error message pops up.
      - When the user switches back to **Road Editing**, "Simulation is now paused" pops up.
      - When the user resets the grid, "Simulation reseted" pops up.

In addition to the UI, <code>keyPressed()</code> in <code>sketch.js</code> was modified to prevent a user from going into **Begin Simulation** mode without at least one complete road. The definition of a complete road is up to you:
  - [ ] A complete road must go from A to B, where B is at the edge, even if it is only two tiles long.
  - [ ] A complete road can also be a single tile at the edge of the grid.
